### PR TITLE
Add tests (and fix implementation for) EBU-TT-D style conversion

### DIFF
--- a/ebu_tt_live/bindings/__init__.py
+++ b/ebu_tt_live/bindings/__init__.py
@@ -152,7 +152,7 @@ class style_type(StyledElementMixin, IDMixin, SizingValidationMixin, SemanticVal
                 return self._ordered_styles
             ordered_styles = [self]
             if self.style is not None:
-                for style_id in self.style:
+                for style_id in self.style[::-1]: # Reverse style references: last reference should take precedence
                     try:
                         style_elem = dataset['tt_element'].get_element_by_id(elem_id=style_id, elem_type=style_type)
                         cascading_styles = style_elem.ordered_styles(dataset=dataset)

--- a/ebu_tt_live/bindings/__init__.py
+++ b/ebu_tt_live/bindings/__init__.py
@@ -1197,4 +1197,15 @@ class d_style_type(raw.d_style_type):
         )
         return instance
 
+    @classmethod
+    def merge_styles(main_style, parents):
+        if len(parents) == 0:
+            return main_style
+        elif len(parents) == 1:
+            # actually merge something
+            pass
+        else:
+            return merge_styles(parents[0], parents[1:])
+        
+
 raw.d_style_type._SetSupersedingClass(d_style_type)

--- a/ebu_tt_live/bindings/__init__.py
+++ b/ebu_tt_live/bindings/__init__.py
@@ -1197,15 +1197,4 @@ class d_style_type(raw.d_style_type):
         )
         return instance
 
-    @classmethod
-    def merge_styles(main_style, parents):
-        if len(parents) == 0:
-            return main_style
-        elif len(parents) == 1:
-            # actually merge something
-            pass
-        else:
-            return merge_styles(parents[0], parents[1:])
-        
-
 raw.d_style_type._SetSupersedingClass(d_style_type)

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -201,8 +201,8 @@ class EBUTT3EBUTTDConverter(object):
                         if parent_style.padding:
                             region_in.padding = parent_style.padding
                 else:
-                    if region_style.padding:
-                        region_in.padding = region_style.padding
+                 if region_style.padding:
+                    region_in.padding = region_style.padding
         new_elem = d_region_type(
             *self.convert_children(region_in, dataset),
             id=region_in.id,
@@ -228,7 +228,7 @@ class EBUTT3EBUTTDConverter(object):
 
     def convert_style(self, style_in, dataset):
         ordered_styles = style_in.ordered_styles(dataset)
-        computed_style = style_in._semantic_copy(None)
+        computed_style = style_type(id = style_in.id)
         for s in ordered_styles:
             computed_style.add(s)
         color = computed_style.color

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -220,6 +220,8 @@ class EBUTT3EBUTTDConverter(object):
         parent_styles = []
         if style_in.style:
             parent_styles = [s for s in dataset['styles'] if s.id in style_in.style]
+            for style in parent_styles:
+                style_in.add(style)
         color = style_in.color
         if color is not None:
             if isinstance(color, ebuttdt.namedColorType):

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -207,6 +207,7 @@ class EBUTT3EBUTTDConverter(object):
         return new_elem
 
     def convert_styling(self, styling_in, dataset):
+        dataset['styles'] = styling_in.style
         new_elem = d_styling_type(
             *self.convert_children(styling_in, dataset)
         )
@@ -216,6 +217,9 @@ class EBUTT3EBUTTDConverter(object):
         return new_elem
 
     def convert_style(self, style_in, dataset):
+        parent_styles = []
+        if style_in.style:
+            parent_styles = [s for s in dataset['styles'] if s.id in style_in.style]
         color = style_in.color
         if color is not None:
             if isinstance(color, ebuttdt.namedColorType):

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -193,6 +193,11 @@ class EBUTT3EBUTTDConverter(object):
         if extent is not None:
             if isinstance(extent, ebuttdt.cellExtentType):
                 extent = ebuttdt.convert_cell_region_to_percentage(extent, dataset['cellResolution'])
+        if region_in.padding == None:
+            region_styles = [style for style in region_in.validated_styles if style.id in region_in.style]
+            for region_style in region_styles:
+                 if region_style.padding:
+                    region_in.padding = region_style.padding
         new_elem = d_region_type(
             *self.convert_children(region_in, dataset),
             id=region_in.id,

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -131,7 +131,6 @@ class EBUTT3EBUTTDConverter(object):
     def convert_tt(self, tt_in, dataset):
         dataset['timeBase'] = tt_in.timeBase
         dataset['cellResolution'] = tt_in.cellResolution
-        dataset['tt_element'] = tt_in
         new_elem = ttd(
             head=self.convert_element(tt_in.head, dataset),
             body=self.convert_element(tt_in.body, dataset),

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -228,7 +228,7 @@ class EBUTT3EBUTTDConverter(object):
 
     def convert_style(self, style_in, dataset):
         ordered_styles = style_in.ordered_styles(dataset)
-        computed_style = style_type(id = style_in.id)
+        computed_style = style_type(id=style_in.id)
         for s in ordered_styles:
             computed_style.add(s)
         color = computed_style.color

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -193,10 +193,16 @@ class EBUTT3EBUTTDConverter(object):
             if isinstance(extent, ebuttdt.cellExtentType):
                 extent = ebuttdt.convert_cell_region_to_percentage(extent, dataset['cellResolution'])
         if region_in.padding == None:
-            region_styles = [style for style in region_in.validated_styles if style.id in region_in.style]
-            for region_style in region_styles:
-                 if region_style.padding:
-                    region_in.padding = region_style.padding
+            region_validated_styles = [style for style in region_in.validated_styles if style.id in region_in.style]
+            for region_style in region_validated_styles:
+                parent_styles = region_style.ordered_styles(dataset)
+                if parent_styles:
+                    for parent_style in parent_styles:
+                        if parent_style.padding:
+                            region_in.padding = parent_style.padding
+                else:
+                    if region_style.padding:
+                        region_in.padding = region_style.padding
         new_elem = d_region_type(
             *self.convert_children(region_in, dataset),
             id=region_in.id,

--- a/testing/bdd/conftest.py
+++ b/testing/bdd/conftest.py
@@ -92,8 +92,10 @@ def gen_document(template_file, template_dict):
 def when_doc_generated(test_context, template_dict, template_file):
     # This is a more standard-compliant way to do this
     xml_file = template_file.render(template_dict)
+    print(xml_file)
     document = EBUTT3Document.create_from_xml(xml_file)
     test_context['document'] = document
+    print(test_context['document'].get_xml())
 
 
 @given('the first document is generated')
@@ -126,6 +128,7 @@ def convert_to_ebuttd(test_context):
     converted_bindings = ebuttd_converter.convert_document(test_context['document'].binding)
     ebuttd_document = EBUTTDDocument.create_from_raw_binding(converted_bindings)
     test_context['ebuttd_document'] = ebuttd_document
+    print(ebuttd_document.get_xml())
 
 
 @then('EBUTTD document is valid')

--- a/testing/bdd/conftest.py
+++ b/testing/bdd/conftest.py
@@ -92,10 +92,8 @@ def gen_document(template_file, template_dict):
 def when_doc_generated(test_context, template_dict, template_file):
     # This is a more standard-compliant way to do this
     xml_file = template_file.render(template_dict)
-    print(xml_file)
     document = EBUTT3Document.create_from_xml(xml_file)
     test_context['document'] = document
-    print(test_context['document'].get_xml())
 
 
 @given('the first document is generated')
@@ -128,7 +126,6 @@ def convert_to_ebuttd(test_context):
     converted_bindings = ebuttd_converter.convert_document(test_context['document'].binding)
     ebuttd_document = EBUTTDDocument.create_from_raw_binding(converted_bindings)
     test_context['ebuttd_document'] = ebuttd_document
-    print(ebuttd_document.get_xml())
 
 
 @then('EBUTTD document is valid')

--- a/testing/bdd/features/metadata/ebuttd_required_metadata.feature
+++ b/testing/bdd/features/metadata/ebuttd_required_metadata.feature
@@ -1,3 +1,4 @@
+@metadata @document @ebuttd_conversion 
 Feature: Converted EBUTTD file contains required metadata elements
 
   Scenario: It adds two conformsToStandard elements to the EBU-TT-D metadata

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -1,5 +1,8 @@
 Feature: Remove style elements that refer to other style elements
 
+  Examples:
+    | xml_file                     |
+    | style_element_references.xml |
 
   Scenario: Convert style element with reference to another style to a presentationally equivalent
     Given an xml file <xml_file>
@@ -20,6 +23,54 @@ Feature: Remove style elements that refer to other style elements
     And   the ebu_tt_d document contains style "s4" with attribute "color" set to "#ffff00ff"
     And   the ebu_tt_d document contains style "s4" with attribute "backgroundColor" set to "#000000ff"
 
-    Examples:
-      | xml_file                     |
-      | style_element_references.xml |
+  Scenario: Convert padding specifed on style applied to region to padding specified only on region when padding is on both style and region
+    Given an xml file <xml_file>
+    When  it contains style "s1"
+    And   style "s1" has attribute "padding" set to "10px"
+    And   it contains region "r1"
+    And   region "r1" has attribute "style" set to "s1"
+    And   region "r1" has attribute "padding" set to "5px"
+    When  the document is generated
+    And   the EBU-TT-Live document is converted to EBU-TT-D
+    Then  EBUTTD document is valid
+
+  Scenario: Convert padding specifed on style applied to region to padding specified only on region when padding is only on style
+    Given an xml file <xml_file>
+    When  it contains style "s1"
+    And   style "s1" has attribute "padding" set to "10px"
+    And   it contains region "r1"
+    And   region "r1" has attribute "style" set to "s1"
+    When  the document is generated
+    And   the EBU-TT-Live document is converted to EBU-TT-D
+    Then   EBUTTD document is valid 
+    And  the ebu_tt_d document contains region "r1" with attribute "padding" set to "10px"
+
+
+  Scenario: Convert padding specifed on 2 styles applied to a region to padding specified only on region when padding is only on style
+    Given an xml file <xml_file>
+    When  it contains style "s1"
+    And   style "s1" has attribute "padding" set to "10px"
+    When  it contains style "s2"
+    And   style "s1" has attribute "padding" set to "5px"
+    And   it contains region "r1"
+    And   region "r1" has attribute "style" set to "s1 s2"
+    When  the document is generated
+    And   the EBU-TT-Live document is converted to EBU-TT-D
+    Then  EBUTTD document is valid 
+    And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "5px"
+
+
+  Scenario: Convert padding specifed on 2 styles where one inherits from another applied to a region to padding specified only on region when padding is only on style
+    Given an xml file <xml_file>
+    When  it contains style "s1"
+    And   style "s1" has attribute "padding" set to "10px"
+    When  it contains style "s2"
+    And   style "s1" has attribute "padding" set to "5px"
+    When  it contains style "s3"
+    And   style "s1" has attribute "color" set to "white"
+    And   it contains region "r1"
+    And   region "r1" has attribute "style" set to "s1 s3"
+    When  the document is generated
+    And   the EBU-TT-Live document is converted to EBU-TT-D
+    Then  EBUTTD document is valid 
+    And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "5px"

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -1,3 +1,4 @@
+@styles @document @ebuttd_conversion 
 Feature: Remove style elements that refer to other style elements
 
   Examples:

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -4,7 +4,8 @@ Feature: Remove style elements that refer to other style elements
     | xml_file                     |
     | style_element_references.xml |
 
-  Scenario: Convert style element with reference to another style to a presentationally equivalent
+
+  Scenario: Convert style element with reference to another style to a presentationally equivalent one
     Given an xml file <xml_file>
     When  it contains style "s1"
     And   style "s1" has attribute "color" set to "white"
@@ -24,6 +25,7 @@ Feature: Remove style elements that refer to other style elements
     And   the ebu_tt_d document contains style "s4" with attribute "color" set to "#ffff00ff"
     And   the ebu_tt_d document contains style "s4" with attribute "backgroundColor" set to "#000000ff"
 
+
   Scenario: Convert padding specifed on style applied to region to padding specified only on region when padding is on both style and region
     Given an xml file <xml_file>
     When  it contains style "s1"
@@ -35,6 +37,7 @@ Feature: Remove style elements that refer to other style elements
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  EBUTTD document is valid
+
 
   Scenario: Convert padding specifed on style applied to region to padding specified only on region when padding is only on style
     Given an xml file <xml_file>

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -17,6 +17,7 @@ Feature: Remove style elements that refer to other style elements
     And   it contains style "s4"
     And   style "s4" has attribute "style" set to "s2 s3"
     And   style "s4" has attribute "color" set to "yellow"
+    And   it contains some text with style "s4"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  the ebu_tt_d document contains style "s4" with attribute "fontFamily" set to "monospace"
@@ -30,6 +31,7 @@ Feature: Remove style elements that refer to other style elements
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1"
     And   region "r1" has attribute "padding" set to "5px"
+    And   it contains some text with style "s1"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  EBUTTD document is valid
@@ -40,10 +42,11 @@ Feature: Remove style elements that refer to other style elements
     And   style "s1" has attribute "padding" set to "10px"
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1"
+    And   it contains some text with style "s1"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
-    Then   EBUTTD document is valid 
-    And  the ebu_tt_d document contains region "r1" with attribute "padding" set to "10px"
+    Then  EBUTTD document is valid 
+    And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "10px"
 
 
   Scenario: Convert padding specifed on 2 styles applied to a region to padding specified only on region when padding is only on style
@@ -51,9 +54,10 @@ Feature: Remove style elements that refer to other style elements
     When  it contains style "s1"
     And   style "s1" has attribute "padding" set to "10px"
     When  it contains style "s2"
-    And   style "s1" has attribute "padding" set to "5px"
+    And   style "s2" has attribute "padding" set to "5px"
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1 s2"
+    And   it contains some text with style "s2"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  EBUTTD document is valid 
@@ -65,11 +69,13 @@ Feature: Remove style elements that refer to other style elements
     When  it contains style "s1"
     And   style "s1" has attribute "padding" set to "10px"
     When  it contains style "s2"
-    And   style "s1" has attribute "padding" set to "5px"
+    And   style "s2" has attribute "padding" set to "5px"
     When  it contains style "s3"
-    And   style "s1" has attribute "color" set to "white"
+    And   style "s3" has attribute "color" set to "white"
+    And   style "s3" has attribute "style" set to "s2"
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1 s3"
+    And   it contains some text with style "s3"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  EBUTTD document is valid 

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -8,23 +8,23 @@ Feature: Remove style elements that refer to other style elements
 
   Scenario: Convert style element with reference to another style to a presentationally equivalent one
     Given an xml file <xml_file>
-    When  it contains style "s1"
-    And   style "s1" has attribute "color" set to "white"
-    And   style "s1" has attribute "backgroundColor" set to "black"
-    And   it contains style "s2"
-    And   style "s2" has attribute "style" set to "s1"
-    And   style "s2" has attribute "fontFamily" set to "reith"
-    And   it contains style "s3"
-    And   style "s3" has attribute "fontFamily" set to "monospace"
-    And   it contains style "s4"
-    And   style "s4" has attribute "style" set to "s2 s3"
-    And   style "s4" has attribute "color" set to "yellow"
-    And   it contains some text with style "s4"
+    When  it contains style "s_default"
+    And   style "s_default" has attribute "color" set to "white"
+    And   style "s_default" has attribute "backgroundColor" set to "black"
+    And   it contains style "s_font_reith"
+    And   style "s_font_reith" has attribute "style" set to "s_default"
+    And   style "s_font_reith" has attribute "fontFamily" set to "reith"
+    And   it contains style "s_font_monospace"
+    And   style "s_font_monospace" has attribute "fontFamily" set to "monospace"
+    And   it contains style "s_top"
+    And   style "s_top" has attribute "style" set to "s_font_reith s_font_monospace"
+    And   style "s_top" has attribute "color" set to "yellow"
+    And   it contains some text with style "s_top"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
-    Then  the ebu_tt_d document contains style "s4" with attribute "fontFamily" set to "monospace"
-    And   the ebu_tt_d document contains style "s4" with attribute "color" set to "#ffff00ff"
-    And   the ebu_tt_d document contains style "s4" with attribute "backgroundColor" set to "#000000ff"
+    Then  the ebu_tt_d document contains style "s_top" with attribute "fontFamily" set to "monospace"
+    And   the ebu_tt_d document contains style "s_top" with attribute "color" set to "#ffff00ff"
+    And   the ebu_tt_d document contains style "s_top" with attribute "backgroundColor" set to "#000000ff"
 
 
   Scenario: Convert padding specifed on style applied to region to padding specified only on region when padding is on both style and region
@@ -34,10 +34,12 @@ Feature: Remove style elements that refer to other style elements
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1"
     And   region "r1" has attribute "padding" set to "5px"
-    And   it contains some text with style "s1"
+    And   it contains some text with region "r1"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  EBUTTD document is valid
+    And   the ebu_tt_d document contains style "s1" without a "padding" attribute
+    And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "5px"
 
 
   Scenario: Convert padding specifed on style applied to region to padding specified only on region when padding is only on style
@@ -46,10 +48,11 @@ Feature: Remove style elements that refer to other style elements
     And   style "s1" has attribute "padding" set to "10px"
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1"
-    And   it contains some text with style "s1"
+    And   it contains some text with region "r1"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
-    Then  EBUTTD document is valid 
+    Then  EBUTTD document is valid
+    And   the ebu_tt_d document contains style "s1" without a "padding" attribute
     And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "10px"
 
 
@@ -61,10 +64,10 @@ Feature: Remove style elements that refer to other style elements
     And   style "s2" has attribute "padding" set to "5px"
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1 s2"
-    And   it contains some text with style "s2"
+    And   it contains some text with region "r1"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
-    Then  EBUTTD document is valid 
+    Then  EBUTTD document is valid
     And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "5px"
 
 
@@ -79,8 +82,8 @@ Feature: Remove style elements that refer to other style elements
     And   style "s3" has attribute "style" set to "s2"
     And   it contains region "r1"
     And   region "r1" has attribute "style" set to "s1 s3"
-    And   it contains some text with style "s3"
+    And   it contains some text with region "r1"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
-    Then  EBUTTD document is valid 
+    Then  EBUTTD document is valid
     And   the ebu_tt_d document contains region "r1" with attribute "padding" set to "5px"

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -5,16 +5,20 @@ Feature: Remove style elements that refer to other style elements
     Given an xml file <xml_file>
     When  it contains style "s1"
     And   style "s1" has attribute "color" set to "white"
-    And   style "s1" has attribute "fontFamily" set to "Reith"
+    And   style "s1" has attribute "backgroundColor" set to "black"
     And   it contains style "s2"
     And   style "s2" has attribute "style" set to "s1"
-    And   style "s2" has attribute "color" set to "yellow"
-    And   style "s2" has attribute "backgroundColor" set to "black"
+    And   style "s2" has attribute "fontFamily" set to "reith"
+    And   it contains style "s3"
+    And   style "s3" has attribute "fontFamily" set to "monospace"
+    And   it contains style "s4"
+    And   style "s4" has attribute "style" set to "s2 s3"
+    And   style "s4" has attribute "color" set to "yellow"
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
-    Then  the ebu_tt_d document contains style "s2" with attribute "fontFamily" set to "Reith"
-    And   the ebu_tt_d document contains style "s2" with attribute "color" set to "#ffff00ff"
-    And   the ebu_tt_d document contains style "s2" with attribute "backgroundColor" set to "#000000ff"
+    Then  the ebu_tt_d document contains style "s4" with attribute "fontFamily" set to "monospace"
+    And   the ebu_tt_d document contains style "s4" with attribute "color" set to "#ffff00ff"
+    And   the ebu_tt_d document contains style "s4" with attribute "backgroundColor" set to "#000000ff"
 
     Examples:
       | xml_file                     |

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -1,0 +1,21 @@
+Feature: Remove style elements that refer to other style elements
+
+
+  Scenario: Convert style element with reference to another style to a presentationally equivalent
+    Given an xml file <xml_file>
+    When  it contains style "s1"
+    And   style "s1" has attribute "color" set to "white"
+    And   style "s1" has attribute "fontFamily" set to "Reith"
+    And   it contains style "s2"
+    And   style "s2" has attribute "style" set to "s1"
+    And   style "s2" has attribute "color" set to "yellow"
+    And   style "s2" has attribute "backgroundColor" set to "black"
+    When  the document is generated
+    And   the EBU-TT-Live document is converted to EBU-TT-D
+    Then  the ebu_tt_d document contains style "s2" with attribute "fontFamily" set to "Reith"
+    And   the ebu_tt_d document contains style "s2" with attribute "color" set to "yellow"
+    And   the ebu_tt_d document contains style "s2" with attribute "backgroundColor" set to "black"
+
+    Examples:
+      | xml_file                     |
+      | style_element_references.xml |

--- a/testing/bdd/features/styles/ebuttd_style_references.feature
+++ b/testing/bdd/features/styles/ebuttd_style_references.feature
@@ -13,8 +13,8 @@ Feature: Remove style elements that refer to other style elements
     When  the document is generated
     And   the EBU-TT-Live document is converted to EBU-TT-D
     Then  the ebu_tt_d document contains style "s2" with attribute "fontFamily" set to "Reith"
-    And   the ebu_tt_d document contains style "s2" with attribute "color" set to "yellow"
-    And   the ebu_tt_d document contains style "s2" with attribute "backgroundColor" set to "black"
+    And   the ebu_tt_d document contains style "s2" with attribute "color" set to "#ffff00ff"
+    And   the ebu_tt_d document contains style "s2" with attribute "backgroundColor" set to "#000000ff"
 
     Examples:
       | xml_file                     |

--- a/testing/bdd/features/styles/style_attribute_inherited.feature
+++ b/testing/bdd/features/styles/style_attribute_inherited.feature
@@ -2,15 +2,15 @@
 Feature: Compute style attribute on a single EBU-TT Live element
 
   Examples:
-  | xml_file                      | cell_resolution | extent      |
-  | style_attribute_inherited.xml | 32 15           | 320px 150px |
+  | xml_file                      |
+  | style_attribute_inherited.xml |
 
 
   # Inheritance: region (S1) > div (S2) > p (S3) > span (S4)
   Scenario: Inheritable style attributes
     Given an xml file <xml_file>
-    When it has a cell resolution of <cell_resolution>
-    And it has extent of <extent>
+    When it has a cell resolution of "32 15"
+    And it has extent of "320px 150px"
     And it contains style S1 with <style_attribute> value <S1_value>
     And it contains style S2 with <style_attribute> value <S2_value>
     And it contains style S3 with <style_attribute> value <S3_value>
@@ -44,9 +44,7 @@ Feature: Compute style attribute on a single EBU-TT Live element
 
   Scenario: Circular style references should fail
     Given an xml file <xml_file>
-    When it has a cell resolution of <cell_resolution>
-    And it has extent of <extent>
-    And it contains style S1 with <style_attribute> value <S1_value>
+    When it contains style S1 with <style_attribute> value <S1_value>
     And it contains style S2 with <style_attribute> value <S2_value>
     Then document is invalid
 

--- a/testing/bdd/features/styles/style_attribute_inherited.feature
+++ b/testing/bdd/features/styles/style_attribute_inherited.feature
@@ -42,3 +42,14 @@ Feature: Compute style attribute on a single EBU-TT Live element
     |           |          |                |          | tts:wrapOption       | span1   | wrap           |
 
 
+  Scenario: Circular style references should fail
+    Given an xml file <xml_file>
+    When it has a cell resolution of <cell_resolution>
+    And it has extent of <extent>
+    And it contains style S1 with <style_attribute> value <S1_value>
+    And it contains style S2 with <style_attribute> value <S2_value>
+    Then document is invalid
+
+    Examples:
+    | S1_value | S2_value | style_attribute |
+    | S2       | S1       | style           |

--- a/testing/bdd/features/styles/style_attribute_inherited.feature
+++ b/testing/bdd/features/styles/style_attribute_inherited.feature
@@ -46,8 +46,9 @@ Feature: Compute style attribute on a single EBU-TT Live element
     Given an xml file <xml_file>
     When it contains style S1 with <style_attribute> value <S1_value>
     And it contains style S2 with <style_attribute> value <S2_value>
+    And it contains style S3 with <style_attribute> value <S3_value>
     Then document is invalid
 
     Examples:
-    | S1_value | S2_value | style_attribute |
-    | S2       | S1       | style           |
+    | S1_value | S2_value | S3_value | style_attribute |
+    | S2       | S3       | S1       | style           |

--- a/testing/bdd/templates/style_element_references.xml
+++ b/testing/bdd/templates/style_element_references.xml
@@ -34,21 +34,13 @@
     </tt:layout>
   </tt:head>
   <tt:body begin="500ms" dur="00:00:05">
-    {% if regions %}
-    {%for region in regions%}
-    <tt:div region="{{region.id}}">
-      <tt:p begin="500ms" end="3420ms" xml:id="ID005">
-        {% if styles%}
-          {% for style in styles %}
-              <tt:span  style="{{style.id}}" >Some example text...</tt:span>
-          {% endfor %}
-        {% endif %}
-        <tt:br/>
-        <tt:span>And another line</tt:span>
-      </tt:p>
-    </tt:div>
-    {% endfor %}
-    {% endif %}
+      <tt:div>
+        <tt:p begin="500ms" end="3420ms" xml:id="ID006">
+          <tt:span  style="{{text_style}}" >Some example text...</tt:span>
+          <tt:br/>
+          <tt:span>And another line</tt:span>
+        </tt:p>
+      </tt:div>
   </tt:body>
 </tt:tt>
 

--- a/testing/bdd/templates/style_element_references.xml
+++ b/testing/bdd/templates/style_element_references.xml
@@ -35,8 +35,8 @@
   </tt:head>
   <tt:body begin="500ms" dur="00:00:05">
       <tt:div>
-        <tt:p begin="500ms" end="3420ms" xml:id="ID006">
-          <tt:span  style="{{text_style}}" >Some example text...</tt:span>
+        <tt:p begin="500ms" end="3420ms" xml:id="ID006" {% if text_region %} region="{{text_region}}" {% endif %}>
+          <tt:span {% if text_style %} style="{{text_style}}" {% endif %} >Some example text...</tt:span>
           <tt:br/>
           <tt:span>And another line</tt:span>
         </tt:p>

--- a/testing/bdd/templates/style_element_references.xml
+++ b/testing/bdd/templates/style_element_references.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<tt:tt
+        ebuttp:sequenceIdentifier="TestSequence"
+        ebuttp:sequenceNumber="1"
+        ttp:timeBase="media"
+        xml:lang="en-GB"
+        xmlns:ebuttm="urn:ebu:tt:metadata"
+        xmlns:ebuttp="urn:ebu:tt:parameters"
+        xmlns:tt="http://www.w3.org/ns/ttml"
+        xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+        xmlns:tts="http://www.w3.org/ns/ttml#styling"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace"
+        xmlns:f="urn:foreign">
+  <tt:head>
+    <tt:metadata>
+      <ebuttm:documentMetadata/>
+      <f:foreignMetadata>Fake metadata</f:foreignMetadata>
+    </tt:metadata>
+    <tt:styling>
+      {% for style in styles %}
+        <tt:style xml:id="{{ style.id }}"
+          {% if style.style %} style="{{ style.style }}" {% endif %}
+          {% if style.color %} tts:color="{{ style.color }}" {% endif %}
+          {% if style.backgroundColor %} tts:backgroundColor="{{ style.backgroundColor }}" {% endif %}
+          {% if style.fontFamily %} tts:fontFamily="{{ style.fontFamily }}" {% endif %} />
+      {% endfor %}
+    </tt:styling>
+    <tt:layout/>
+  </tt:head>
+  <tt:body begin="500ms" dur="00:00:05">
+    <tt:div>
+      <tt:p begin="500ms" end="3420ms" xml:id="ID005">
+        <tt:span style="s2">Some example text...</tt:span>
+        <tt:br/>
+        <tt:span>And another line</tt:span>
+      </tt:p>
+    </tt:div>
+  </tt:body>
+</tt:tt>

--- a/testing/bdd/templates/style_element_references.xml
+++ b/testing/bdd/templates/style_element_references.xml
@@ -18,22 +18,37 @@
     </tt:metadata>
     <tt:styling>
       {% for style in styles %}
-        <tt:style xml:id="{{ style.id }}"
-          {% if style.style %} style="{{ style.style }}" {% endif %}
-          {% if style.color %} tts:color="{{ style.color }}" {% endif %}
-          {% if style.backgroundColor %} tts:backgroundColor="{{ style.backgroundColor }}" {% endif %}
-          {% if style.fontFamily %} tts:fontFamily="{{ style.fontFamily }}" {% endif %} />
-      {% endfor %}
+        <tt:style xml:id="{{ style.id }}" {% if style.style %} style="{{ style.style }}" {% endif %}
+        {% if style.color %} tts:color="{{ style.color }}" {% endif %}
+        {% if style.backgroundColor %} tts:backgroundColor="{{ style.backgroundColor }}" {% endif %}
+        {% if style.fontFamily %} tts:fontFamily="{{ style.fontFamily }}" {% endif %} 
+        {% if style.padding %} tts:padding="{{style.padding}}" {% endif %}  />
+        {% endfor %}
     </tt:styling>
-    <tt:layout/>
+    <tt:layout>
+       {%if regions%}
+        {% for region in regions%}
+          <tt:region xml:id="{{region.id}}" style="{{region.style}}" {% if region.padding %} tts:padding="{{region.padding}}" {% endif %} tts:displayAlign="after" tts:extent="71.25% 24%" tts:origin="14.375% 60%" tts:overflow="visible" tts:writingMode="lrtb" />
+        {% endfor %}
+      {% endif %}
+    </tt:layout>
   </tt:head>
   <tt:body begin="500ms" dur="00:00:05">
-    <tt:div>
+    {% if regions %}
+    {%for region in regions%}
+    <tt:div region="{{region.id}}">
       <tt:p begin="500ms" end="3420ms" xml:id="ID005">
-        <tt:span style="s2">Some example text...</tt:span>
+        {% if styles%}
+          {% for style in styles %}
+              <tt:span  style="{{style.id}}" >Some example text...</tt:span>
+          {% endfor %}
+        {% endif %}
         <tt:br/>
         <tt:span>And another line</tt:span>
       </tt:p>
     </tt:div>
+    {% endfor %}
+    {% endif %}
   </tt:body>
 </tt:tt>
+

--- a/testing/bdd/test_ebuttd_style_references.py
+++ b/testing/bdd/test_ebuttd_style_references.py
@@ -20,7 +20,6 @@ def when_style_has_attribute(test_context, style_name, attribute, value):
 
 @then(parsers.parse('the ebu_tt_d document contains style "{style_name}" with attribute "{attribute}" set to "{value}"'))
 def then_converted_document_has_style(test_context, style_name, attribute, value):
-    print(test_context['document'].get_xml())
     print(test_context['ebuttd_document'].get_xml())
     ebuttd_document = test_context['ebuttd_document']
     tree = ET.fromstring(ebuttd_document.get_xml())

--- a/testing/bdd/test_ebuttd_style_references.py
+++ b/testing/bdd/test_ebuttd_style_references.py
@@ -17,25 +17,16 @@ def when_it_contains_style(test_context, template_dict, style_name):
 def when_style_has_attribute(test_context, style_name, attribute, value):
     test_context[style_name][attribute] = value
 
+
 @when(parsers.parse('it contains some text with style "{style_name}"'))
 def when_style_has_attribute(template_dict, style_name):
     template_dict['text_style'] = style_name
 
 
-@then(parsers.parse('the ebu_tt_d document contains style "{style_name}" with attribute "{attribute}" set to "{value}"'))
-def then_converted_document_has_style(test_context, style_name, attribute, value):
-    ebuttd_document = test_context['ebuttd_document']
-    tree = ET.fromstring(ebuttd_document.get_xml())
-    elements = tree.findall('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %style_name)
-    assert len(elements) == 1
-    assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
+@when(parsers.parse('it contains some text with region "{region_name}"'))
+def when_style_has_attribute(template_dict, region_name):
+    template_dict['text_region'] = region_name
 
-@then(parsers.parse('the ebu_tt_d document contains region "{region_id}" with attribute "{attribute}" set to "{value}"'))
-def then_converted_document_has_style(test_context, region_id, attribute, value):
-    ebuttd_document = test_context['ebuttd_document']
-    tree = ET.fromstring(ebuttd_document.get_xml())
-    element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}layout/{http://www.w3.org/ns/ttml}region[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %region_id)
-    assert value == element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute)
 
 @when(parsers.parse('it contains region "{region_id}"'))
 def when_it_contains_region(test_context, template_dict, region_id):
@@ -49,3 +40,28 @@ def when_it_contains_region(test_context, template_dict, region_id):
 @when(parsers.parse('region "{region_id}" has attribute "{attribute}" set to "{value}"'))
 def when_region_has_attribute(test_context, region_id, attribute, value):
     test_context[region_id][attribute] = value
+
+
+@then(parsers.parse('the ebu_tt_d document contains style "{style_name}" with attribute "{attribute}" set to "{value}"'))
+def then_converted_document_has_style(test_context, style_name, attribute, value):
+    ebuttd_document = test_context['ebuttd_document']
+    tree = ET.fromstring(ebuttd_document.get_xml())
+    elements = tree.findall('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %style_name)
+    assert len(elements) == 1
+    assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
+
+
+@then(parsers.parse('the ebu_tt_d document contains region "{region_id}" with attribute "{attribute}" set to "{value}"'))
+def then_converted_document_has_region_with_styling_attribute(test_context, region_id, attribute, value):
+    ebuttd_document = test_context['ebuttd_document']
+    tree = ET.fromstring(ebuttd_document.get_xml())
+    element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}layout/{http://www.w3.org/ns/ttml}region[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %region_id)
+    assert element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
+
+
+@then(parsers.parse('the ebu_tt_d document contains style "{style_id}" without a "{attribute}" attribute'))
+def then_converted_document_has_style_without_attribute(test_context, style_id, attribute):
+    ebuttd_document = test_context['ebuttd_document']
+    tree = ET.fromstring(ebuttd_document.get_xml())
+    element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' % style_id)
+    assert element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == None

--- a/testing/bdd/test_ebuttd_style_references.py
+++ b/testing/bdd/test_ebuttd_style_references.py
@@ -26,3 +26,23 @@ def then_converted_document_has_style(test_context, style_name, attribute, value
     elements = tree.findall('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %style_name)
     assert len(elements) == 1
     assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
+
+@then(parsers.parse('the ebu_tt_d document contains region "{region_id}" with attribute "{attribute}" set to "{value}"'))
+def then_converted_document_has_style(test_context, region_id, attribute, value):
+    ebuttd_document = test_context['ebuttd_document']
+    tree = ET.fromstring(ebuttd_document.get_xml())
+    element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}layout/{http://www.w3.org/ns/ttml}region[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %region_id)
+    assert value == element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) 
+
+@when(parsers.parse('it contains region "{region_id}"'))
+def when_it_contains_region(test_context, template_dict, region_id):
+    if 'regions' not in template_dict:
+        template_dict['regions'] = list()
+    region = {"id": region_id}    
+    template_dict['regions'].append(region)
+    test_context[region_id] = region
+
+
+@when(parsers.parse('region "{region_id}" has attribute "{attribute}" set to "{value}"'))
+def when_region_has_attribute(test_context, region_id, attribute, value):
+    test_context[region_id][attribute] = value

--- a/testing/bdd/test_ebuttd_style_references.py
+++ b/testing/bdd/test_ebuttd_style_references.py
@@ -8,7 +8,7 @@ scenarios('features/styles/ebuttd_style_references.feature')
 def when_it_contains_style(test_context, template_dict, style_name):
     if 'styles' not in template_dict:
         template_dict['styles'] = list()
-    style = {"id": style_name}    
+    style = {"id": style_name}
     template_dict['styles'].append(style)
     test_context[style_name] = style
 
@@ -19,12 +19,12 @@ def when_style_has_attribute(test_context, style_name, attribute, value):
 
 
 @when(parsers.parse('it contains some text with style "{style_name}"'))
-def when_style_has_attribute(template_dict, style_name):
+def when_text_has_style(template_dict, style_name):
     template_dict['text_style'] = style_name
 
 
 @when(parsers.parse('it contains some text with region "{region_name}"'))
-def when_style_has_attribute(template_dict, region_name):
+def when_text_has_region(template_dict, region_name):
     template_dict['text_region'] = region_name
 
 
@@ -32,7 +32,7 @@ def when_style_has_attribute(template_dict, region_name):
 def when_it_contains_region(test_context, template_dict, region_id):
     if 'regions' not in template_dict:
         template_dict['regions'] = list()
-    region = {"id": region_id}    
+    region = {"id": region_id}
     template_dict['regions'].append(region)
     test_context[region_id] = region
 
@@ -46,7 +46,9 @@ def when_region_has_attribute(test_context, region_id, attribute, value):
 def then_converted_document_has_style(test_context, style_name, attribute, value):
     ebuttd_document = test_context['ebuttd_document']
     tree = ET.fromstring(ebuttd_document.get_xml())
-    elements = tree.findall('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %style_name)
+    elements = tree.findall('{http://www.w3.org/ns/ttml}head/'
+                            '{http://www.w3.org/ns/ttml}styling/'
+                            '{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' % style_name)
     assert len(elements) == 1
     assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
 
@@ -55,13 +57,19 @@ def then_converted_document_has_style(test_context, style_name, attribute, value
 def then_converted_document_has_region_with_styling_attribute(test_context, region_id, attribute, value):
     ebuttd_document = test_context['ebuttd_document']
     tree = ET.fromstring(ebuttd_document.get_xml())
-    element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}layout/{http://www.w3.org/ns/ttml}region[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %region_id)
-    assert element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
+    elements = tree.findall('{http://www.w3.org/ns/ttml}head/'
+                            '{http://www.w3.org/ns/ttml}layout/'
+                            '{http://www.w3.org/ns/ttml}region[@{http://www.w3.org/XML/1998/namespace}id="%s"]' % region_id)
+    assert len(elements) == 1
+    assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value
 
 
 @then(parsers.parse('the ebu_tt_d document contains style "{style_id}" without a "{attribute}" attribute'))
 def then_converted_document_has_style_without_attribute(test_context, style_id, attribute):
     ebuttd_document = test_context['ebuttd_document']
     tree = ET.fromstring(ebuttd_document.get_xml())
-    element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' % style_id)
-    assert element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == None
+    elements = tree.findall('{http://www.w3.org/ns/ttml}head/'
+                            '{http://www.w3.org/ns/ttml}styling/'
+                            '{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' % style_id)
+    assert len(elements) == 1
+    assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == None

--- a/testing/bdd/test_ebuttd_style_references.py
+++ b/testing/bdd/test_ebuttd_style_references.py
@@ -1,0 +1,29 @@
+from pytest_bdd import scenarios, when, then, given, parsers
+import xml.etree.ElementTree as ET
+
+scenarios('features/styles/ebuttd_style_references.feature')
+
+
+@when(parsers.parse('it contains style "{style_name}"'))
+def when_it_contains_style(test_context, template_dict, style_name):
+    if 'styles' not in template_dict:
+        template_dict['styles'] = list()
+    style = {"id": style_name}    
+    template_dict['styles'].append(style)
+    test_context[style_name] = style
+
+
+@when(parsers.parse('style "{style_name}" has attribute "{attribute}" set to "{value}"'))
+def when_style_has_attribute(test_context, style_name, attribute, value):
+    test_context[style_name][attribute] = value
+
+
+@then(parsers.parse('the ebu_tt_d document contains style "{style_name}" with attribute "{attribute}" set to "{value}"'))
+def then_converted_document_has_style(test_context, style_name, attribute, value):
+    print(test_context['document'].get_xml())
+    print(test_context['ebuttd_document'].get_xml())
+    ebuttd_document = test_context['ebuttd_document']
+    tree = ET.fromstring(ebuttd_document.get_xml())
+    elements = tree.findall('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %style_name)
+    assert len(elements) == 1
+    assert elements[0].get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) == value

--- a/testing/bdd/test_ebuttd_style_references.py
+++ b/testing/bdd/test_ebuttd_style_references.py
@@ -17,10 +17,13 @@ def when_it_contains_style(test_context, template_dict, style_name):
 def when_style_has_attribute(test_context, style_name, attribute, value):
     test_context[style_name][attribute] = value
 
+@when(parsers.parse('it contains some text with style "{style_name}"'))
+def when_style_has_attribute(template_dict, style_name):
+    template_dict['text_style'] = style_name
+
 
 @then(parsers.parse('the ebu_tt_d document contains style "{style_name}" with attribute "{attribute}" set to "{value}"'))
 def then_converted_document_has_style(test_context, style_name, attribute, value):
-    print(test_context['ebuttd_document'].get_xml())
     ebuttd_document = test_context['ebuttd_document']
     tree = ET.fromstring(ebuttd_document.get_xml())
     elements = tree.findall('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}styling/{http://www.w3.org/ns/ttml}style[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %style_name)
@@ -32,7 +35,7 @@ def then_converted_document_has_style(test_context, region_id, attribute, value)
     ebuttd_document = test_context['ebuttd_document']
     tree = ET.fromstring(ebuttd_document.get_xml())
     element = tree.find('{http://www.w3.org/ns/ttml}head/{http://www.w3.org/ns/ttml}layout/{http://www.w3.org/ns/ttml}region[@{http://www.w3.org/XML/1998/namespace}id="%s"]' %region_id)
-    assert value == element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute) 
+    assert value == element.get('{http://www.w3.org/ns/ttml#styling}%s' % attribute)
 
 @when(parsers.parse('it contains region "{region_id}"'))
 def when_it_contains_region(test_context, template_dict, region_id):

--- a/testing/bdd/test_style.py
+++ b/testing/bdd/test_style.py
@@ -1,4 +1,4 @@
-from pytest_bdd import when, scenarios, then
+from pytest_bdd import when, scenarios, then, parsers
 from ebu_tt_live.clocks.media import MediaClock
 from ebu_tt_live.bindings import ebuttdt
 from ebu_tt_live.documents.converters import EBUTT3EBUTTDConverter
@@ -13,11 +13,13 @@ scenarios('features/styles/lineHeight.feature')
 
 
 @when('it has a cell resolution of <cell_resolution>')
+@when(parsers.parse('it has a cell resolution of "{cell_resolution}"'))
 def when_cell_resolution(template_dict, cell_resolution):
     template_dict['cell_resolution'] = cell_resolution
 
 
 @when('it has extent of <extent>')
+@when(parsers.parse('it has extent of "{extent}"'))
 def when_extent(template_dict, extent):
     template_dict['extent'] = extent
 


### PR DESCRIPTION
This checks that, when converted from EBU-TT-Live to EBU-TT-D, the `styling > style` elements do not contain nested references. Instead the styling information contained in referenced styles should be merged with the parent style, keeping the original style ID.

So if there are 4 style elements like so:
```xml
<style id="s1" ... />
<style id="s2" style="s1" ... />
<style id="s3" ... />
<style id="s4" style="s2 s3" ... />
```
Then the converted document will contain style s4 with all the elements of s3, s2 and s1 with priority to the attributes of s4 > s3 > s2 > s1.

This PR also moves padding defined in `<style>` elements to their corresponding `<region>`