### PR TITLE
Specify UTF-8 encoding on output documents

### DIFF
--- a/ebu_tt_live/documents/ebutt3.py
+++ b/ebu_tt_live/documents/ebutt3.py
@@ -139,6 +139,9 @@ class EBUTT3Document(TimelineUtilMixin, SubtitleDocument, EBUTTDocumentBase):
     # The sequence the document belongs to
     _sequence = None
 
+    # Encoding to use when creating XML representations
+    _encoding = 'UTF-8'
+
     def __init__(self,
                  time_base, sequence_number, sequence_identifier, lang,
                  clock_mode=None, availability_time=None,
@@ -425,11 +428,12 @@ class EBUTT3Document(TimelineUtilMixin, SubtitleDocument, EBUTTDocumentBase):
             )
 
     def get_xml(self, indent='  ', newl='\n'):
-        return self._ebutt3_content.toxml(
+        return str(self._ebutt3_content.toxml(
+            encoding=self._encoding,
             bds=self._get_bds(),
             indent=indent,
             newl=newl
-        )
+        ), encoding=self._encoding)
 
     def get_dom(self):
         return self._ebutt3_content.toDOM()

--- a/ebu_tt_live/documents/ebuttd.py
+++ b/ebu_tt_live/documents/ebuttd.py
@@ -14,6 +14,9 @@ class EBUTTDDocument(SubtitleDocument, TimelineUtilMixin):
     _ebuttd_content = None
     _implicit_ns = None
 
+    # Encoding to use when creating XML representations
+    _encoding = 'UTF-8'
+
     def __init__(self, lang):
         self._ebuttd_content = bindings.ttd(
             timeBase='media',
@@ -75,11 +78,12 @@ class EBUTTDDocument(SubtitleDocument, TimelineUtilMixin):
             )
 
     def get_xml(self, indent=None, newl=None):
-        return self._ebuttd_content.toxml(
+        return str(self._ebuttd_content.toxml(
+            encoding=self._encoding,
             bds=self._get_bds(),
             indent=indent,
             newl=newl
-        )
+        ), encoding=self._encoding)
 
     def get_dom(self):
         return self._ebuttd_content.toDOM(


### PR DESCRIPTION
For BBC ticket MSPA-1014. Ensures that XML representations of the output both are encoded as UTF-8 and specify the UTF-8 encoding in the XML header string.