### PR TITLE
Handle metadata children of p elements

### DIFF
--- a/testing/bdd/conftest.py
+++ b/testing/bdd/conftest.py
@@ -133,12 +133,26 @@ def gen_second_document_fixture(test_context, template_dict, template_file_two):
 
 @when('the EBU-TT-Live document is denested')
 def convert_to_ebuttd(test_context):
+    print('denester input')
+    print(test_context["document"].get_xml())
     test_context["document"] = DenesterNode.denest(test_context["document"])
+    print('denester output')
+    print(test_context["document"].get_xml())
+
+@then('the EBU-TT-Live document is valid')
+def then_ebutt3_document_valid(test_context):
+    ebutt3_document = test_context['document']
+    ebutt3_document.validate()
+    print('valid EBU-TT-Live document:')
+    print(ebutt3_document.get_xml())
+    assert isinstance(ebutt3_document, EBUTT3Document)
 
 @when('the EBU-TT-Live document is converted to EBU-TT-D')
 def convert_to_ebuttd(test_context):
     ebuttd_converter = EBUTT3EBUTTDConverter(None)
     doc_xml = test_context["document"].get_xml()
+    print('convert to EBU-TT-D. Incoming doc:')
+    print(doc_xml)
     ebutt3_doc = EBUTT3Document.create_from_xml(doc_xml)
     converted_bindings = ebuttd_converter.convert_document(ebutt3_doc.binding)
     ebuttd_document = EBUTTDDocument.create_from_raw_binding(converted_bindings)
@@ -148,6 +162,8 @@ def convert_to_ebuttd(test_context):
 def then_ebuttd_document_valid(test_context):
     ebuttd_document = test_context['ebuttd_document']
     ebuttd_document.validate()
+    print('valid EBU-TT-D document:')
+    print(ebuttd_document.get_xml())
     assert isinstance(ebuttd_document, EBUTTDDocument)
 
 def timestr_to_timedelta(time_str, time_base):

--- a/testing/bdd/features/nesting/ebuttd_nested_elements.feature
+++ b/testing/bdd/features/nesting/ebuttd_nested_elements.feature
@@ -115,3 +115,13 @@ Feature: Merging nested elements
         Examples:
             | xml_file                   |
             | nested_spans_hardcoded.xml |
+
+    Scenario: p elements with metadata can be denested
+        Given an xml file <xml_file>
+        When the document is generated
+        And the EBU-TT-Live document is denested
+        Then the EBU-TT-Live document is valid
+
+        Examples:
+            | xml_file                        |
+            | nested_p_metadata_hardcoded.xml |

--- a/testing/bdd/templates/nested_p_metadata_hardcoded.xml
+++ b/testing/bdd/templates/nested_p_metadata_hardcoded.xml
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<tt:tt
+	ebuttp:sequenceIdentifier="TestSequence"
+	ebuttp:sequenceNumber="1"
+	ttp:clockMode="local"
+	ttp:timeBase="clock"
+	xmlns:ebuttm="urn:ebu:tt:metadata"
+	xmlns:ebuttp="urn:ebu:tt:parameters"
+	xmlns:tt="http://www.w3.org/ns/ttml"
+	xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+	xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	xmlns:f="urn:foreign"
+	xmlns:tts="http://www.w3.org/ns/ttml#styling"
+	xmlns:ebutts="urn:ebu:tt:style"
+	xml:lang="en"
+	>
+<tt:head>
+<tt:metadata>
+<ebuttm:documentMetadata></ebuttm:documentMetadata>
+<ttm:agent type="person" xml:id="Sp1">
+<ttm:name type="other">
+					New 1
+</ttm:name>
+</ttm:agent>
+<ttm:agent type="person" xml:id="Sp2">
+<ttm:name type="other">
+					New 2
+</ttm:name>
+</ttm:agent>
+</tt:metadata>
+<tt:styling>
+<tt:style xml:id="S1" tts:fontSize="1c 2c" ebutts:linePadding="1c" tts:textAlign="start" tts:lineHeight="2c" />
+<tt:style xml:id="S2" tts:textAlign="center" />
+<tt:style xml:id="S3" tts:color="white" tts:backgroundColor="black" />
+<tt:style xml:id="S7" tts:color="cyan" tts:backgroundColor="black" />
+</tt:styling>
+<tt:layout>
+<tt:region xml:id="R41" tts:origin="0c 1c" tts:extent="40c 2c" tts:displayAlign="after" />
+<tt:region xml:id="R61" tts:origin="8c 3c" tts:extent="24c 2c" tts:displayAlign="after" />
+<tt:region xml:id="R149" tts:origin="4c 1c" tts:extent="4c 2c" tts:displayAlign="after" />
+</tt:layout>
+</tt:head>
+<tt:body ttm:role="caption">
+<tt:div style="S1">
+<tt:p xml:id="C550" region="R41" style="S2" begin="10:26:27.92" end="10:26:29.44"><tt:span style="S3">Yes, it is.</tt:span></tt:p>
+<tt:p xml:id="C551_1" region="R149" begin="10:26:31.16" end="10:26:33.36" style="S2"><tt:metadata></tt:metadata><tt:span style="S3">BELL</tt:span></tt:p>
+<tt:p xml:id="C551_2" region="R61" begin="10:26:31.16" end="10:26:33.36" style="S2"><tt:metadata></tt:metadata><tt:span style="S7">Row, row, row your boat.</tt:span></tt:p>
+<tt:p xml:id="C552" region="R41" style="S2" begin="10:26:33.36" end="10:26:35.56"><tt:span style="S3">Correct. Next category...</tt:span></tt:p>
+</tt:div>
+</tt:body>
+</tt:tt>


### PR DESCRIPTION
Fixes a crash when denesting a document with a `p` element containing a `metadata` child element.