### PR TITLE
Mspa 1237 active area precision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ init:
 
 initnpm:
 ifeq ("$(wildcard node_modules)","")
-	npm install nunjucks
+	npm install nunjucks@3.2.0
 else 
-	npm update nunjucks
+	npm update nunjucks@3.2.0
 endif
 
 test:

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -24,11 +24,29 @@ log = logging.getLogger(__name__)
 DEFAULT_CELL_FONT_SIZE = CellFontSizeType('1c')
 
 
+def roundAndStrip(value, dp):
+    """
+    Round the supplied value to dp decimal places and tidy the end.
+
+    After rounding, strips any trailing zeros after the decimal point,
+    and the decimal point itself if that's the last thing we're left with.
+    """
+    if (dp < 0):
+        value = round(value, dp)
+        dp = 0
+    template = '{{:.{}f}}'.format(dp)
+    rv = template.format(value)
+    if (dp > 0):
+        rv = rv.rstrip('0').rstrip('.')
+    return rv
+
+
 class EBUTT3EBUTTDConverter(object):
 
     _media_clock = None
     _font_size_style_template = 'autogenFontStyle_{}_{}_{}'
-    _number_template = '{:.2f}'
+    _fontSize_max_dp = 2
+    _activeArea_max_dp = 3
     _dataset_key_for_font_styles = 'adjusted_sizing_styles'
     _semantic_dataset = None
 
@@ -83,10 +101,13 @@ class EBUTT3EBUTTDConverter(object):
         adjusted_line_height = 'n'
 
         if isinstance(line_height, PercentageLineHeightType):
-            adjusted_line_height = self._number_template.format(line_height.vertical)
+            adjusted_line_height = roundAndStrip(
+                line_height.vertical, self._fontSize_max_dp)
 
-        h = 'n' if horizontal is None else self._number_template.format(horizontal)
-        v = 'n' if vertical is None else self._number_template.format(vertical)
+        h = 'n' if horizontal is None \
+            else roundAndStrip(horizontal, self._fontSize_max_dp)
+        v = 'n' if vertical is None \
+            else roundAndStrip(vertical, self._fontSize_max_dp)
         font_style_id = \
             self._font_size_style_template.format(
                 h, v, adjusted_line_height)
@@ -271,8 +292,12 @@ class EBUTT3EBUTTDConverter(object):
 
             if region_found:
                 document.activeArea = '{}% {}% {}% {}%'.format(
-                    left, top, right - left, bottom - top
+                    roundAndStrip(left, self._activeArea_max_dp),
+                    roundAndStrip(top, self._activeArea_max_dp),
+                    roundAndStrip(right - left, self._activeArea_max_dp),
+                    roundAndStrip(bottom - top, self._activeArea_max_dp)
                 )
+                log.info('Found active regions, set document.activeArea to {}'.format(document.activeArea))
             else:
                 log.warn('None of the active regions found')
         else:

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -119,10 +119,12 @@ class EBUTT3EBUTTDConverter(object):
             font_size = None
             if vertical is not None:
                 if horizontal is None:
-                    font_size = roundAndStrip(vertical, 2) + '%'
+                    font_size = \
+                        roundAndStrip(vertical, self._fontSize_max_dp) + '%'
                 else:
-                    font_size = roundAndStrip(horizontal, 2) + '% ' + \
-                        roundAndStrip(vertical, 2) + '%'
+                    font_size = \
+                        roundAndStrip(horizontal, self._fontSize_max_dp) + '% ' \
+                        + roundAndStrip(vertical, self._fontSize_max_dp) + '%'
 
             instance = d_style_type(
                 id=font_style_id,

--- a/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
+++ b/ebu_tt_live/bindings/converters/ebutt3_ebuttd.py
@@ -119,11 +119,10 @@ class EBUTT3EBUTTDConverter(object):
             font_size = None
             if vertical is not None:
                 if horizontal is None:
-                    font_size = ebuttdt.PercentageFontSizeType(
-                        round(vertical, 2))
+                    font_size = roundAndStrip(vertical, 2) + '%'
                 else:
-                    font_size = ebuttdt.PercentageFontSizeType(
-                        round(horizontal, 2), round(vertical, 2))
+                    font_size = roundAndStrip(horizontal, 2) + '% ' + \
+                        roundAndStrip(vertical, 2) + '%'
 
             instance = d_style_type(
                 id=font_style_id,

--- a/ebu_tt_live/bindings/test/test_roundAndStrip.py
+++ b/ebu_tt_live/bindings/test/test_roundAndStrip.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+from ebu_tt_live.bindings.converters.ebutt3_ebuttd import roundAndStrip
+
+
+class testRoundAndStrip(TestCase):
+
+    def testRoundUp(self):
+        self.assertEqual(
+            roundAndStrip(123.45, 1),
+            '123.5'
+        )
+        self.assertEqual(
+            roundAndStrip(123.456, 2),
+            '123.46'
+        )
+
+    def testRoundDown(self):
+        self.assertEqual(
+            roundAndStrip(123.44, 1),
+            '123.4'
+        )
+        self.assertEqual(
+            roundAndStrip(123.554, 2),
+            '123.55'
+        )
+
+    def testStripTrailingZeros(self):
+        self.assertEqual(
+            roundAndStrip(123.100, 3),
+            '123.1'
+        )
+        self.assertEqual(
+            roundAndStrip(123.000, 2),
+            '123'
+        )
+
+
+    def testStripTrailingDecimalPoint(self):
+        self.assertEqual(
+            roundAndStrip(122.999, 2),
+            '123'
+        )
+
+    def testDontStripSignificantZeros(self):
+        self.assertEqual(
+            roundAndStrip(100, 0),
+            '100'
+        )
+
+    def testNegativeDecimalPlaces(self):
+        self.assertEqual(
+            roundAndStrip(123, -1),
+            '120'
+        )

--- a/ebu_tt_live/node/test/test_encoder.py
+++ b/ebu_tt_live/node/test/test_encoder.py
@@ -154,7 +154,7 @@ class TestEBUTTDEncoderSuccess(TestCase):
         self.assertIsNotNone(output_doc.binding.activeArea)
         self.assertEqual(
             output_doc.binding.activeArea.xsdLiteral(),
-            '25.0% 75.0% 37.5% 25.0%')
+            '25% 75% 37.5% 25%')
 
     def test_calculate_active_area_two_regions_one_unreferenced(self):
         doc = self._create_test_document()
@@ -179,7 +179,7 @@ class TestEBUTTDEncoderSuccess(TestCase):
         self.assertIsNotNone(output_doc.binding.activeArea)
         self.assertEqual(
             output_doc.binding.activeArea.xsdLiteral(),
-            '25.0% 75.0% 37.5% 25.0%')
+            '25% 75% 37.5% 25%')
 
     def test_calculate_active_area_two_regions_both_unreferenced(self):
         doc = self._create_test_document()
@@ -216,7 +216,7 @@ class TestEBUTTDEncoderSuccess(TestCase):
         self.assertIsNotNone(output_doc.binding.activeArea)
         self.assertEqual(
             output_doc.binding.activeArea.xsdLiteral(),
-            '12.5% 75.0% 50.0% 33.33%')
+            '12.5% 75% 50% 33.33%')
 
     def test_metadata(self):
         doc = self._create_test_document()

--- a/testing/bdd/features/nesting/ebuttd_nested_elements.feature
+++ b/testing/bdd/features/nesting/ebuttd_nested_elements.feature
@@ -108,9 +108,9 @@ Feature: Merging nested elements
         And the EBU-TT-Live document is denested
         And the EBU-TT-Live document is converted to EBU-TT-D
         Then EBUTTD document is valid
-        And any span with the style "nestSizing" also has the style "autogenFontStyle_n_50.00_n"
-        And any span with the style "nestSizingnestSizing" also has the style "autogenFontStyle_n_25.00_n"
-        And any span with the style "nestSizingnestSizingnestSizing" also has the style "autogenFontStyle_n_12.50_n"
+        And any span with the style "nestSizing" also has the style "autogenFontStyle_n_50_n"
+        And any span with the style "nestSizingnestSizing" also has the style "autogenFontStyle_n_25_n"
+        And any span with the style "nestSizingnestSizingnestSizing" also has the style "autogenFontStyle_n_12.5_n"
 
         Examples:
             | xml_file                   |

--- a/testing/bdd/features/styles/lineHeight.feature
+++ b/testing/bdd/features/styles/lineHeight.feature
@@ -36,9 +36,15 @@ Feature: lineHeight relative to fontSize
     |          |           |          |           |          |           |          |           | p1      | normal         |
     | 1c       |           |          |           |          |           |          |           | p1      | 1c             |
     | 1c       |           | 2c       |           |          |           |          |           | p1      | 2c             |
-    | 1c       | 3c        | 2c       | 3c        |          |           |          |           | p1      | 2c             |  # Independence of fontSize
-    | 1c       | 3c        | 20px     | 3c        |          |           |          |           | p1      | 2c             |  # Independence of fontSize
-    | 1c       | 2c        | 100%     | 3c        |          |           |          |           | p1      | 3c             |  # Dependence of fontSize
-    | 1c       | 2c        | 100%     | 30px      |          |           |          |           | p1      | 3c             |  # Dependence of fontSize
-    | 100%     | 2c        |          | 3c        |          |           |          |           | p1      | 2c             |  # Dependence of fontSize in the same context
-    | normal   | 1c        | 100%     | 2c        | 150%     |           | 50%      | 4c        | p1      | 3c             | # lineHeight and fontSize on span are ignored, p fontSize inherited 
+    # Independence of fontSize:
+    | 1c       | 3c        | 2c       | 3c        |          |           |          |           | p1      | 2c             |
+    # Independence of fontSize:
+    | 1c       | 3c        | 20px     | 3c        |          |           |          |           | p1      | 2c             |
+    # Dependence of fontSize:
+    | 1c       | 2c        | 100%     | 3c        |          |           |          |           | p1      | 3c             |
+    # Dependence of fontSize:
+    | 1c       | 2c        | 100%     | 30px      |          |           |          |           | p1      | 3c             |
+    # Dependence of fontSize in the same context:
+    | 100%     | 2c        |          | 3c        |          |           |          |           | p1      | 2c             |
+    # lineHeight and fontSize on span are ignored, p fontSize inherited:
+    | normal   | 1c        | 100%     | 2c        | 150%     |           | 50%      | 4c        | p1      | 3c             |

--- a/testing/bdd/features/styles/style_attribute_simple.feature
+++ b/testing/bdd/features/styles/style_attribute_simple.feature
@@ -21,15 +21,20 @@ Feature: Compute style attribute on a single EBU-TT Live element
 
     Examples:
     | R1_value | S1_value  | S2_value | S3_value       | S4_value | style_attribute     | elem_id | computed_value |
-    |          |           |          |                |          | tts:backgroundColor | span1   | transparent    |  # default value
-    |          | blue      |          |                |          | tts:backgroundColor | span1   | transparent    |  # does not inherit from region
-    |          |           |          | blue           |          | tts:backgroundColor | span1   | transparent    |  # does not inherit from parent
-    |          |           |          |                | blue     | tts:backgroundColor | span1   | blue           |  # does compute if specified directly
+    # default value:
+    |          |           |          |                |          | tts:backgroundColor | span1   | transparent    |
+    # does not inherit from region:
+    |          | blue      |          |                |          | tts:backgroundColor | span1   | transparent    |
+    # does not inherit from parent:
+    |          |           |          | blue           |          | tts:backgroundColor | span1   | transparent    |
+    # does compute if specified directly:
+    |          |           |          |                | blue     | tts:backgroundColor | span1   | blue           |
     |          |           |          |                |          | tts:padding         | span1   | 0px            |
     |          |           |          |                | 10px     | tts:padding         | span1   | 10px           |
     |          | 10px      |          |                |          | tts:padding         | span1   | 0px            |
     |          | 10px      |          |                |          | tts:padding         | R1      | 10px           |
-    | 10px     | 20px      |          |                |          | tts:padding         | R1      | 10px           |  # padding defined directly on region overrides S1
+    # padding defined directly on region overrides S1:
+    | 10px     | 20px      |          |                |          | tts:padding         | R1      | 10px           |
     |          |           |          |                |          | tts:unicodeBidi     | span1   | normal         |
     |          |           |          | embed          |          | tts:unicodeBidi     | span1   | normal         |
     |          |           |          |                | embed    | tts:unicodeBidi     | span1   | embed          |

--- a/testing/bdd/features/timing/retimingDelayNode.feature
+++ b/testing/bdd/features/timing/retimingDelayNode.feature
@@ -3,7 +3,8 @@ Feature: Delay of a document sequence
 
   Examples:
   | xml_file      |
-  | delayNode.xml |  # Empty span timing creates the span without timing. It does not omit it.
+  | delayNode.xml |
+  # Note: Empty span timing creates the span without timing. It does not omit it.
 
 
   # SPEC-CONFORMANCE.md R114    

--- a/testing/bdd/features/unit_conversion/ebuttd_line_height_conversion.feature
+++ b/testing/bdd/features/unit_conversion/ebuttd_line_height_conversion.feature
@@ -19,13 +19,13 @@ Feature: EBU-TT-D lineHeight conversion
 
         Examples:
             | lineHeight | fontSize | style_id                          | ebu_tt_d_value |
-            | 2c         | 2c       | autogenFontStyle_n_200.00_100.00  | 100%           |
-            | 3c         | 2c       | autogenFontStyle_n_200.00_150.00  | 150%           |
-            | 1c         | 2c       | autogenFontStyle_n_200.00_50.00   | 50%            |
-            | 100%       | 2c       | autogenFontStyle_n_200.00_100.00  | 100%           |
-            | 120%       | 2c       | autogenFontStyle_n_200.00_120.00  | 120%           |
-            | 120.2%     | 2c       | autogenFontStyle_n_200.00_120.20  | 120.2%         |
-            | 120.36%    | 2c       | autogenFontStyle_n_200.00_120.36  | 120.36%        |
-            | 120.123%   | 2c       | autogenFontStyle_n_200.00_120.12  | 120.12%        |
-            | normal     | 2c       | autogenFontStyle_n_200.00_n       | normal         |
+            | 2c         | 2c       | autogenFontStyle_n_200_100  | 100%           |
+            | 3c         | 2c       | autogenFontStyle_n_200_150  | 150%           |
+            | 1c         | 2c       | autogenFontStyle_n_200_50   | 50%            |
+            | 100%       | 2c       | autogenFontStyle_n_200_100  | 100%           |
+            | 120%       | 2c       | autogenFontStyle_n_200_120  | 120%           |
+            | 120.2%     | 2c       | autogenFontStyle_n_200_120.2  | 120.2%         |
+            | 120.36%    | 2c       | autogenFontStyle_n_200_120.36  | 120.36%        |
+            | 120.123%   | 2c       | autogenFontStyle_n_200_120.12  | 120.12%        |
+            | normal     | 2c       | autogenFontStyle_n_200_n       | normal         |
 

--- a/testing/bdd/templates/unnested_spans_hardcoded.xml
+++ b/testing/bdd/templates/unnested_spans_hardcoded.xml
@@ -19,12 +19,12 @@
         <tt:style xml:id="outerGreeninnerRed" tts:color="#FF0000" />
         <tt:style xml:id="outerGreeninnerYellow" tts:color="#FFFF00" />
         <tt:style xml:id="outerinnerRed" tts:backgroundColor="#000000" tts:color="#FF0000" />
-        <tt:style tts:fontSize="200.0%" xml:id="autogenFontStyle_n_200.00"/>
-        <tt:style tts:fontSize="300.0%" xml:id="autogenFontStyle_n_300.00"/>
-        <tt:style tts:fontSize="75.0%" xml:id="autogenFontStyle_n_75.00"/>
-        <tt:style tts:fontSize="50.0%" xml:id="autogenFontStyle_n_50.00"/>
-        <tt:style tts:fontSize="25.0%" xml:id="autogenFontStyle_n_25.00"/>
-        <tt:style tts:fontSize="12.5%" xml:id="autogenFontStyle_n_12.50"/>
+        <tt:style tts:fontSize="200%" xml:id="autogenFontStyle_n_200"/>
+        <tt:style tts:fontSize="300%" xml:id="autogenFontStyle_n_300"/>
+        <tt:style tts:fontSize="75%" xml:id="autogenFontStyle_n_75"/>
+        <tt:style tts:fontSize="50%" xml:id="autogenFontStyle_n_50"/>
+        <tt:style tts:fontSize="25%" xml:id="autogenFontStyle_n_25"/>
+        <tt:style tts:fontSize="12.5%" xml:id="autogenFontStyle_n_12.5"/>
     </tt:styling>
     <tt:layout>
         <tt:region xml:id="R1" tts:origin="14% 60%" tts:extent="71.25% 24%" style="outer"/>
@@ -32,21 +32,21 @@
   </tt:head>
   <tt:body begin="500ms" dur="00:00:05">
     <tt:div xml:id="d1" xml:lang="fr">
-      <tt:p style="autogenFontStyle_n_200.00" xml:id="p1">
-        <tt:span style="autogenFontStyle_n_200.00 outer">
+      <tt:p style="autogenFontStyle_n_200" xml:id="p1">
+        <tt:span style="autogenFontStyle_n_200 outer">
             Parent text
         </tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outerinnerYellow">text1<tt:br/></tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outer"></tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outerinnerYellow">text133</tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outer"><tt:br/></tt:span>
-        <tt:span style="autogenFontStyle_n_300.00 outerinnerWhite">text2</tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outer"></tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outer">text3</tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outer"></tt:span>
+        <tt:span style="autogenFontStyle_n_200 outerinnerYellow">text1<tt:br/></tt:span>
+        <tt:span style="autogenFontStyle_n_200 outer"></tt:span>
+        <tt:span style="autogenFontStyle_n_200 outerinnerYellow">text133</tt:span>
+        <tt:span style="autogenFontStyle_n_200 outer"><tt:br/></tt:span>
+        <tt:span style="autogenFontStyle_n_300 outerinnerWhite">text2</tt:span>
+        <tt:span style="autogenFontStyle_n_200 outer"></tt:span>
+        <tt:span style="autogenFontStyle_n_200 outer">text3</tt:span>
+        <tt:span style="autogenFontStyle_n_200 outer"></tt:span>
         <tt:span style="outerinnerRed"></tt:span>
-        <tt:span style="autogenFontStyle_n_200.00 outer">text 7</tt:span>
-        <tt:span style="autogenFontStyle_n_75.00 outerGreen"></tt:span>
+        <tt:span style="autogenFontStyle_n_200 outer">text 7</tt:span>
+        <tt:span style="autogenFontStyle_n_75 outerGreen"></tt:span>
         <tt:span xml:id="sp7" style="outerGreeninnerRed">text 17</tt:span>
         <tt:span style="outerGreen"></tt:span>
         <tt:span style="outerGreeninnerYellow">text 17</tt:span>
@@ -54,11 +54,11 @@
         <tt:span xml:id="sp8" style="nest"></tt:span>
         <tt:span xml:id="sp9" style="nest"></tt:span>
         <tt:span style="nest"></tt:span>
-        <tt:span xml:id="sp10" style="autogenFontStyle_n_50.00 nestSizing"></tt:span>
-        <tt:span xml:id="sp11" style="autogenFontStyle_n_25.00 nestSizingnestSizing"></tt:span>
-        <tt:span xml:id="sp12" style="autogenFontStyle_n_12.50 nestSizingnestSizingnestSizing"></tt:span>
-        <tt:span style="autogenFontStyle_n_25.00 nestSizingnestSizing"></tt:span>
-        <tt:span style="autogenFontStyle_n_50.00 nestSizing"></tt:span>
+        <tt:span xml:id="sp10" style="autogenFontStyle_n_50 nestSizing"></tt:span>
+        <tt:span xml:id="sp11" style="autogenFontStyle_n_25 nestSizingnestSizing"></tt:span>
+        <tt:span xml:id="sp12" style="autogenFontStyle_n_12.5 nestSizingnestSizingnestSizing"></tt:span>
+        <tt:span style="autogenFontStyle_n_25 nestSizingnestSizing"></tt:span>
+        <tt:span style="autogenFontStyle_n_50 nestSizing"></tt:span>
       </tt:p>
     </tt:div>
   </tt:body>

--- a/testing/bdd/test_ebuttd_nested_elements.py
+++ b/testing/bdd/test_ebuttd_nested_elements.py
@@ -59,7 +59,7 @@ def combine_span_styles(test_context):
     document = test_context['ebuttd_document']
     tree = ET.fromstring(document.get_xml())
     elements = tree.findall('{http://www.w3.org/ns/ttml}body/{http://www.w3.org/ns/ttml}div/{http://www.w3.org/ns/ttml}p/{http://www.w3.org/ns/ttml}span')
-    assert elements[1].get("style") == "autogenFontStyle_n_200.00_n outerinnerYellow"
+    assert elements[1].get("style") == "autogenFontStyle_n_200_n outerinnerYellow"
 
 @then('the second span contains a br')
 def second_span_contains_br(test_context):


### PR DESCRIPTION
Tidy up how we generate decimal fractions when converting to EBU-TT-D, so that we set the precision as a number of decimal places, and strip any trailing zeros, and if all that's left is a decimal point, strip that too.

While we're at it, I discovered that updates to upstream libraries mean that our previous practice of adding explanatory comments to lines in cucumber BDD feature files is no longer supported, and is officially disallowed in Cucumber, so move them to separate lines so that they run okay.

This change is helpful if the input document uses regions with a lot of decimal places in their origins or extents, because it allows us to limit the decimal places of the values in the activeArea attribute.

It also slightly reduces file sizes, by using values like `200%` for a font size instead of `200.0%`; this change gets propagated to the auto generated style names, which are therefore also shorter.